### PR TITLE
Added tigera/api for numorstring type

### DIFF
--- a/pkg/crd/known_types.go
+++ b/pkg/crd/known_types.go
@@ -81,10 +81,11 @@ var KnownPackages = map[string]PackageOverride{
 		p.AddPackage(pkg) // get the rest of the types
 	},
 
-	// numorstring could come from two different places. It was moved to the api repository
+	// numorstring could come from different places. It was moved to the api repository
 	// around the time of Calico v3.20.
 	"github.com/projectcalico/libcalico-go/lib/numorstring": numOrString,
 	"github.com/projectcalico/api/pkg/lib/numorstring":      numOrString,
+	"github.com/tigera/api/pkg/lib/numorstring":             numOrString,
 
 	"k8s.io/apimachinery/pkg/api/resource": func(p *Parser, pkg *loader.Package) {
 		p.Schemata[TypeIdent{Name: "Quantity", Package: pkg}] = apiext.JSONSchemaProps{


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

Here we try to make `projectcalico/api` and `tigera/api` two different packages and be independent with each other. Hence, numorstring is the library in both packages.  